### PR TITLE
Ensure byte is returned when reading IO expander register

### DIFF
--- a/lib/circuits_sim/device/pi4ioe5v6416lex.ex
+++ b/lib/circuits_sim/device/pi4ioe5v6416lex.ex
@@ -30,7 +30,7 @@ defmodule CircuitsSim.Device.PI4IOE5V6416LEX do
     def write_register(state, reg, value), do: put_in(state.registers[reg], <<value>>)
 
     @impl SimpleI2CDevice
-    def read_register(state, reg), do: {state.registers[reg], state}
+    def read_register(state, reg), do: {state.registers[reg] || <<0>>, state}
 
     @impl SimpleI2CDevice
     def render(state) do


### PR DESCRIPTION
Without this, the register read would return `nil` if it had not previously been written when simulating the IO expander. Rather than prefill all registers, this just returns an empty byte if there is no register value