### PR TITLE
Add send_message to I2CServer and SPIServer

### DIFF
--- a/lib/circuits_sim/i2c/i2c_server.ex
+++ b/lib/circuits_sim/i2c/i2c_server.ex
@@ -78,6 +78,11 @@ defmodule CircuitsSim.I2C.I2CServer do
     end
   end
 
+  @spec send_message(String.t(), I2C.address(), any()) :: any()
+  def send_message(bus_name, address, message) do
+    GenServer.call(via_name(bus_name, address), {:send_message, message})
+  end
+
   @impl GenServer
   def init(init_args) do
     device = Keyword.fetch!(init_args, :device)
@@ -118,6 +123,11 @@ defmodule CircuitsSim.I2C.I2CServer do
 
   def handle_call(:render, _from, state) do
     {:reply, do_render(state), state}
+  end
+
+  def handle_call({:send_message, message}, _from, state) do
+    {result, new_device} = I2CDevice.handle_message(state.device, message)
+    {:reply, result, %{state | device: new_device}}
   end
 
   defp do_read(%{protocol: I2CDevice} = state, count) do

--- a/lib/circuits_sim/spi/spi_server.ex
+++ b/lib/circuits_sim/spi/spi_server.ex
@@ -69,6 +69,11 @@ defmodule CircuitsSim.SPI.SPIServer do
     gen_call(bus_name, :render)
   end
 
+  @spec send_message(String.t(), any()) :: any()
+  def send_message(bus_name, message) do
+    GenServer.call(via_name(bus_name), {:send_message, message})
+  end
+
   @impl GenServer
   def init(init_args) do
     device = Keyword.fetch!(init_args, :device)
@@ -84,5 +89,10 @@ defmodule CircuitsSim.SPI.SPIServer do
 
   def handle_call(:render, _from, state) do
     {:reply, SPIDevice.render(state.device), state}
+  end
+
+  def handle_call({:send_message, message}, _from, state) do
+    {result, new_device} = SPIDevice.handle_message(state.device, message)
+    {:reply, result, %{state | device: new_device}}
   end
 end


### PR DESCRIPTION
Support `send_message` in I2CServer and SPIServer so that we can do something like GPIOButton at https://github.com/elixir-circuits/circuits_sim/blob/main/lib/circuits_sim/device/gpio_button.ex#L48