### PR TITLE
fix(veml7700): broken render function

### DIFF
--- a/lib/circuits_sim/device/veml7700.ex
+++ b/lib/circuits_sim/device/veml7700.ex
@@ -124,8 +124,7 @@ defmodule CircuitsSim.Device.VEML7700 do
 
     @impl I2CDevice
     def render(state) do
-      light_lux = Float.round(state.light_lux * 1.0, 3)
-      "Light: #{light_lux} lux"
+      "Ambient light sensor raw output: #{state.als_output}"
     end
 
     @impl I2CDevice

--- a/test/circuits_sim/device/veml7700_test.exs
+++ b/test/circuits_sim/device/veml7700_test.exs
@@ -15,6 +15,11 @@ defmodule CircuitsSim.Device.VEML7700Test do
     [i2c_bus: i2c_bus]
   end
 
+  test "setting VEML7700 state", %{i2c_bus: i2c_bus} do
+    VEML7700Sim.set_state(i2c_bus, @i2c_address, als_output: 123)
+    assert I2CServer.render(i2c_bus, @i2c_address) == "Ambient light sensor raw output: 123"
+  end
+
   test "reads and writes registers", %{i2c_bus: i2c_bus} do
     VEML7700Sim.set_state(i2c_bus, @i2c_address, als_config: 0, als_output: 440)
 

--- a/test/circuits_sim_test.exs
+++ b/test/circuits_sim_test.exs
@@ -1,4 +1,8 @@
 defmodule CircuitsSimTest do
   use ExUnit.Case
   doctest CircuitsSim
+
+  test "info/0 does not crash" do
+    CircuitsSim.info()
+  end
 end


### PR DESCRIPTION
### Issue

`CircuitsSim.info` calls crash because the render function in VEML7700 sim is not implemented properly.

```elixir
ex(1)> CircuitsSim.info

09:07:51.690 [error] GenServer {CircuitSim.DeviceRegistry, {:i2c, "i2c-1", 72}} terminating
** (KeyError) key :light_lux not found in: %CircuitsSim.Device.VEML7700{als_config: 0, als_threshold_high: 0, als_threshold_low: 0, als_power_saving: 0, als_output: 0, white_output: 0, interrupt_status: 0}
    (circuits_sim 0.1.0) lib/circuits_sim/device/veml7700.ex:127: CircuitsSim.I2C.I2CDevice.CircuitsSim.Device.VEML7700.render/1
    (circuits_sim 0.1.0) lib/circuits_sim/i2c/i2c_server.ex:125: CircuitsSim.I2C.I2CServer.handle_call/3
    (stdlib 5.0) gen_server.erl:1113: :gen_server.try_handle_call/4
    (stdlib 5.0) gen_server.erl:1142: :gen_server.handle_msg/6
    (stdlib 5.0) proc_lib.erl:241: :proc_lib.init_p_do_apply/3
```

### After fix

![CleanShot 2023-05-30 at 22 26 27](https://github.com/elixir-circuits/circuits_sim/assets/7563926/e4bd43cd-3352-40f7-ab90-ac2fbe9c1790)

### Notes

- Because calculating lux from raw is not so simple, I decided to just print a raw value for simplicity