### PR TITLE
Support returning I2C errors from reads

### DIFF
--- a/lib/circuits_sim/device/ads7138.ex
+++ b/lib/circuits_sim/device/ads7138.ex
@@ -38,7 +38,7 @@ defmodule CircuitsSim.Device.ADS7138 do
       # for reading, but we'll include it here just in case.
       last = state.current + count
       result = for reg <- state.current..last, into: <<>>, do: read_register(state, reg)
-      {result, %{state | current: last}}
+      {{:ok, result}, %{state | current: last}}
     end
 
     @impl I2CDevice
@@ -63,13 +63,13 @@ defmodule CircuitsSim.Device.ADS7138 do
 
     @impl I2CDevice
     def write_read(state, <<@single_register_read, register>>, 1) do
-      {read_register(state, register), %{state | current: register}}
+      {{:ok, read_register(state, register)}, %{state | current: register}}
     end
 
     def write_read(state, <<@continuous_register_read, register>>, count) do
       last = state.current + count
       result = for reg <- state.current..last, into: <<>>, do: read_register(state, reg)
-      {result, %{state | current: register}}
+      {{:ok, result}, %{state | current: register}}
     end
 
     @impl I2CDevice

--- a/lib/circuits_sim/device/aht20.ex
+++ b/lib/circuits_sim/device/aht20.ex
@@ -41,11 +41,11 @@ defmodule CircuitsSim.Device.AHT20 do
     @impl I2CDevice
     def read(%{current: :measure} = state, count) do
       result = raw_sample(state) |> trim_pad(count)
-      {result, %{state | current: nil}}
+      {{:ok, result}, %{state | current: nil}}
     end
 
     def read(state, count) do
-      {:binary.copy(<<0>>, count), %{state | current: nil}}
+      {{:ok, :binary.copy(<<0>>, count)}, %{state | current: nil}}
     end
 
     @impl I2CDevice
@@ -56,7 +56,7 @@ defmodule CircuitsSim.Device.AHT20 do
 
     @impl I2CDevice
     def write_read(state, _to_write, read_count) do
-      {:binary.copy(<<0>>, read_count), %{state | current: :reset}}
+      {{:ok, :binary.copy(<<0>>, read_count)}, %{state | current: :reset}}
     end
 
     defp trim_pad(x, count) when byte_size(x) >= count, do: :binary.part(x, 0, count)

--- a/lib/circuits_sim/device/sgp30.ex
+++ b/lib/circuits_sim/device/sgp30.ex
@@ -77,16 +77,16 @@ defmodule CircuitsSim.Device.SGP30 do
     @impl I2CDevice
     def read(%{current: :iaq_measure} = state, count) do
       result = binary_for_measure(state) |> trim_pad(count)
-      {result, %{state | current: nil}}
+      {{:ok, result}, %{state | current: nil}}
     end
 
     def read(%{current: :iaq_measure_raw} = state, count) do
       result = binary_for_measure_raw(state) |> trim_pad(count)
-      {result, %{state | current: nil}}
+      {{:ok, result}, %{state | current: nil}}
     end
 
     def read(state, count) do
-      {:binary.copy(<<0>>, count), %{state | current: nil}}
+      {{:ok, :binary.copy(<<0>>, count)}, %{state | current: nil}}
     end
 
     @impl I2CDevice
@@ -98,7 +98,7 @@ defmodule CircuitsSim.Device.SGP30 do
     @impl I2CDevice
     def write_read(state, <<0x36, 0x82>>, count) do
       result = binary_for_serial(state) |> trim_pad(count)
-      {result, %{state | current: nil}}
+      {{:ok, result}, %{state | current: nil}}
     end
 
     def write_read(state, _to_write, read_count) do

--- a/lib/circuits_sim/device/vcnl4040.ex
+++ b/lib/circuits_sim/device/vcnl4040.ex
@@ -86,7 +86,7 @@ defmodule CircuitsSim.Device.VCNL4040 do
 
     @impl I2CDevice
     def read(state, count) do
-      {:binary.copy(<<0>>, count), state}
+      {{:ok, :binary.copy(<<0>>, count)}, state}
     end
 
     @impl I2CDevice
@@ -178,27 +178,27 @@ defmodule CircuitsSim.Device.VCNL4040 do
 
     @impl I2CDevice
     def write_read(state, <<@ps_data_register>>, 2) do
-      {<<state.proximity_raw::little-16>>, state}
+      {{:ok, <<state.proximity_raw::little-16>>}, state}
     end
 
     def write_read(state, <<@als_data_register>>, 2) do
-      {<<state.ambient_light_raw::little-16>>, state}
+      {{:ok, <<state.ambient_light_raw::little-16>>}, state}
     end
 
     def write_read(state, <<@white_data_register>>, 2) do
-      {<<state.white_light_raw::little-16>>, state}
+      {{:ok, <<state.white_light_raw::little-16>>}, state}
     end
 
     def write_read(state, <<@als_ps_interrupt_flag_register>>, 2) do
-      {<<0x00, 0x00>>, state}
+      {{:ok, <<0x00, 0x00>>}, state}
     end
 
     def write_read(state, <<@cmd_device_id>>, 2) do
-      {<<0x86, 0x01>>, state}
+      {{:ok, <<0x86, 0x01>>}, state}
     end
 
     def write_read(state, _value, read_count) do
-      {:binary.copy(<<0>>, read_count), state}
+      {{:ok, :binary.copy(<<0>>, read_count)}, state}
     end
 
     @impl I2CDevice

--- a/lib/circuits_sim/device/veml7700.ex
+++ b/lib/circuits_sim/device/veml7700.ex
@@ -57,7 +57,7 @@ defmodule CircuitsSim.Device.VEML7700 do
 
     @impl I2CDevice
     def read(state, count) do
-      {:binary.copy(<<0>>, count), state}
+      {{:ok, :binary.copy(<<0>>, count)}, state}
     end
 
     @impl I2CDevice
@@ -82,41 +82,41 @@ defmodule CircuitsSim.Device.VEML7700 do
     @impl I2CDevice
     def write_read(state, <<@cmd_als_config>>, read_count) do
       result = <<state.als_config::little-16>> |> trim_pad(read_count)
-      {result, state}
+      {{:ok, result}, state}
     end
 
     def write_read(state, <<@cmd_als_threshold_high>>, read_count) do
       result = <<state.als_threshold_high>> |> trim_pad(read_count)
-      {result, state}
+      {{:ok, result}, state}
     end
 
     def write_read(state, <<@cmd_als_threshold_low>>, read_count) do
       result = <<state.als_threshold_low::little-16>> |> trim_pad(read_count)
-      {result, state}
+      {{:ok, result}, state}
     end
 
     def write_read(state, <<@cmd_als_power_saving>>, read_count) do
       result = <<state.als_power_saving::little-16>> |> trim_pad(read_count)
-      {result, state}
+      {{:ok, result}, state}
     end
 
     def write_read(state, <<@cmd_als_output>>, read_count) do
       result = <<state.als_output::little-16>> |> trim_pad(read_count)
-      {result, state}
+      {{:ok, result}, state}
     end
 
     def write_read(state, <<@cmd_white_output>>, read_count) do
       result = <<state.white_output::little-16>> |> trim_pad(read_count)
-      {result, state}
+      {{:ok, result}, state}
     end
 
     def write_read(state, <<@cmd_interrupt_status>>, read_count) do
       result = <<state.interrupt_status::little-16>> |> trim_pad(read_count)
-      {result, state}
+      {{:ok, result}, state}
     end
 
     def write_read(state, _to_write, read_count) do
-      {:binary.copy(<<0>>, read_count), state}
+      {{:ok, :binary.copy(<<0>>, read_count)}, state}
     end
 
     defp trim_pad(x, count) when byte_size(x) >= count, do: :binary.part(x, 0, count)

--- a/lib/circuits_sim/i2c/i2c_device.ex
+++ b/lib/circuits_sim/i2c/i2c_device.ex
@@ -7,8 +7,12 @@ defprotocol CircuitsSim.I2C.I2CDevice do
 
   @doc """
   Read count bytes
+
+  The first item in the returned tuple is what's returned from the original
+  call to Circuits.I2C.read/2. Try to make the errors consistent with that
+  function if possible.
   """
-  @spec read(t(), non_neg_integer()) :: {binary(), t()}
+  @spec read(t(), non_neg_integer()) :: {{:ok, binary()} | {:error, any()}, t()}
   def read(dev, count)
 
   @doc """
@@ -20,7 +24,7 @@ defprotocol CircuitsSim.I2C.I2CDevice do
   @doc """
   Write data to the device and immediately follow it with a read
   """
-  @spec write_read(t(), binary(), non_neg_integer()) :: {binary(), t()}
+  @spec write_read(t(), binary(), non_neg_integer()) :: {{:ok, binary()} | {:error, any()}, t()}
   def write_read(dev, data, read_count)
 
   @doc """

--- a/lib/circuits_sim/i2c/i2c_server.ex
+++ b/lib/circuits_sim/i2c/i2c_server.ex
@@ -108,7 +108,7 @@ defmodule CircuitsSim.I2C.I2CServer do
   @impl GenServer
   def handle_call({:read, count}, _from, state) do
     {result, new_state} = do_read(state, count)
-    {:reply, {:ok, result}, new_state}
+    {:reply, result, new_state}
   end
 
   def handle_call({:write, data}, _from, state) do
@@ -118,7 +118,7 @@ defmodule CircuitsSim.I2C.I2CServer do
 
   def handle_call({:write_read, data, read_count}, _from, state) do
     {result, new_state} = do_write_read(state, IO.iodata_to_binary(data), read_count)
-    {:reply, {:ok, result}, new_state}
+    {:reply, result, new_state}
   end
 
   def handle_call(:render, _from, state) do
@@ -175,7 +175,7 @@ defmodule CircuitsSim.I2C.I2CServer do
 
   defp simple_read(state, 0, acc) do
     result = acc |> Enum.reverse() |> :binary.list_to_bin()
-    {result, state}
+    {{:ok, result}, state}
   end
 
   defp simple_read(state, count, acc) do


### PR DESCRIPTION
This commit just adds support and raises if a read or write_read's
return value doesn't look right. Everything still is always successful.
