### PR TITLE
Update HexDoc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CircuitsSim
 
 [![Hex version](https://img.shields.io/hexpm/v/circuits_sim.svg "Hex version")](https://hex.pm/packages/circuits_sim)
-[![API docs](https://img.shields.io/hexpm/v/circuits_sim.svg?label=hexdocs "API docs")](https://hexdocs.pm/circuits_sim/CircuitsSim.html)
+[![API docs](https://img.shields.io/hexpm/v/circuits_sim.svg?label=hexdocs "API docs")](https://circuits-sim.hexdocs.pm/CircuitsSim.html)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/elixir-circuits/circuits_sim/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/elixir-circuits/circuits_sim/tree/main)
 [![REUSE status](https://api.reuse.software/badge/github.com/elixir-circuits/circuits_sim)](https://api.reuse.software/info/github.com/elixir-circuits/circuits_sim)
 

--- a/lib/circuits_sim/application.ex
+++ b/lib/circuits_sim/application.ex
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 defmodule CircuitsSim.Application do
-  # See https://hexdocs.pm/elixir/Application.html
+  # See https://elixir.hexdocs.pm/Application.html
   # for more information on OTP Applications
   @moduledoc false
 


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://circuits-sim.hexdocs.pm/CircuitsSim.html): Status 404
⚠️ Verification finished: 1 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>